### PR TITLE
Replace deprecated logging.warn with logging.warning

### DIFF
--- a/feedfinder2.py
+++ b/feedfinder2.py
@@ -41,8 +41,8 @@ class FeedFinder(object):
         try:
             r = requests.get(url, headers={"User-Agent": self.user_agent}, timeout=self.timeout)
         except Exception as e:
-            logging.warn("Error while getting '{0}'".format(url))
-            logging.warn("{0}".format(e))
+            logging.warning("Error while getting '{0}'".format(url))
+            logging.warning("{0}".format(e))
             return None
         return r.text
 


### PR DESCRIPTION
Replace `logging.warn` (deprecated in [Python 2.7, 2011](https://github.com/python/cpython/commit/04d5bc00a219860c69ea17eaa633d3ab9917409f)) with `logging.warning` (added in [Python 2.3, 2003](https://github.com/python/cpython/commit/6fa635df7aa88ae9fd8b41ae42743341316c90f7)).

* https://docs.python.org/3/library/logging.html#logging.Logger.warning
* https://github.com/python/cpython/issues/57444